### PR TITLE
버튼 컴포넌트 클래스 생성 #5 / 그라디언트 구현 메서드 제공 #31

### DIFF
--- a/star/star/Source/Core/UIComponent/GradientButton.swift
+++ b/star/star/Source/Core/UIComponent/GradientButton.swift
@@ -1,0 +1,59 @@
+//
+//  GradientButton.swift
+//  star
+//
+//  Created by t0000-m0112 on 2025-01-23.
+//
+
+import UIKit
+
+final class GradientButton: UIButton {
+    
+    enum GradientDirection {
+        case horizontal // 수평: 좌 -> 우
+        case vertical   // 수직: 상 -> 하
+    }
+    
+    // MARK: - Properties
+    
+    private let gradientLayer = CAGradientLayer()
+    // 그라디언트를 적용할 방향 (기본값: 수평)
+    var gradientDirection: GradientDirection = .horizontal
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+    
+    private func commonInit() {
+        layer.insertSublayer(gradientLayer, at: 0)
+    }
+    
+    // MARK: - Methods
+    
+    func applyGradient(colors: [UIColor]) {
+        gradientLayer.locations = [0.0, 1.0]
+        gradientLayer.colors = colors.map { $0.cgColor }
+        
+        switch gradientDirection {
+        case .horizontal:
+            gradientLayer.startPoint = CGPoint(x: 0.0, y: 0.5)
+            gradientLayer.endPoint = CGPoint(x: 1.0, y: 0.5)
+        case .vertical:
+            gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.0)
+            gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = bounds
+    }
+}

--- a/star/star/Source/DefaultViewController.swift
+++ b/star/star/Source/DefaultViewController.swift
@@ -18,6 +18,16 @@ class DefaultViewController: UIViewController {
         $0.font = Fonts.mainLogo
         $0.textColor = .starPrimaryText
     }
+    
+    private let addStarButton = GradientButton().then {
+        $0.setTitle("스타 추가하기", for: .normal)
+        $0.setTitleColor(.starPrimaryText, for: .normal)
+        $0.titleLabel?.font = Fonts.buttonTitle
+        $0.backgroundColor = .starDisabledTagBG // 그라디언트가 정상적으로 적용될 시 배경색은 보이지 않음
+        $0.layer.cornerRadius = 28
+        $0.clipsToBounds = true
+        $0.gradientDirection = .horizontal
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -29,12 +39,24 @@ class DefaultViewController: UIViewController {
     private func setupUI() {
         view.backgroundColor = .starAppBG
         
-        [mainLogoLabel
+        [mainLogoLabel,
+         addStarButton
         ].forEach { view.addSubview($0) }
         
         mainLogoLabel.snp.makeConstraints { make in
-            make.center.equalToSuperview()
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(150)
         }
+        
+        addStarButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-150)
+            make.height.equalTo(56)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        // applyGradient는 버튼의 레이아웃 적용이 끝난 시점에서 호출해야 함
+        addStarButton.applyGradient(colors: [.starButtonPurple, .starButtonNavy])
     }
 }
 


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
- closes #9 
  - closes #5 
  - closes #31 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- GradientButton 공통 컴포넌트 클래스 구현
  - gradientDirection 변수로 그라디언트 적용 방향을 정할 수 있음 (기본값: 수평)
  - applyGradient 메서드를 사용해 그라디언트를 적용할 수 있음

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/33b863b2-87aa-4aa7-9647-1034baeb9478" height="600"/>

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- @AhnJunGyung 스타 수정/생성 화면에서 요일 선택 버튼을 구현하는 경우 `gradientDirection`를 `.vertical`로 설정해주어야 합니다 (기본값은 horizontal)
-  @name-mun @AhnJunGyung 사용 예시는 아래를 참조해주세요 (DefaultViewController에서도 코드를 확인할 수 있습니다).
  - applyGradient 메서드를 호출하는 타이밍(시점)이 중요합니다!! 본래 CAGradientLayer는 CGRect 타입으로 정의된 frame을 기반으로 설정되는데, 저희는 SnapKit으로 오토레이아웃을 지정해줘야 하기 때문에 레이아웃 지정이 모두 끝난 후 applyGradient 메서드를 호출해줘야 합니다.
  ```swift
      private let addStarButton = GradientButton().then {
          $0.setTitle("스타 추가하기", for: .normal)
          $0.setTitleColor(.starPrimaryText, for: .normal)
          $0.titleLabel?.font = Fonts.buttonTitle
          $0.backgroundColor = .starDisabledTagBG // 그라디언트가 정상적으로 적용될 시 배경색은 보이지 않음
          $0.layer.cornerRadius = 28
          $0.clipsToBounds = true
          $0.gradientDirection = .horizontal
      }
  
      // ...
      
          addStarButton.snp.makeConstraints { make in
              make.centerX.equalToSuperview()
              make.bottom.equalToSuperview().offset(-150)
              make.height.equalTo(56)
              make.leading.trailing.equalToSuperview().inset(20)
          }
          
          // applyGradient는 버튼의 레이아웃 적용이 끝난 시점에서 호출해야 함
          addStarButton.applyGradient(colors: [.starButtonPurple, .starButtonNavy])
  ```
  
  - 이 부분 관련하여 추가로 문제가 발생하지 않는 한, 다음으로는 스크린타임 API 프레임워크를 살펴보겠습니다.
    - 혹시 개발 리소스 지원이 필요하시면 같이 상담해봐용

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
