### PR TITLE
스타리스트 화면 CoreData 연동

### DIFF
--- a/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewController.swift
+++ b/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewController.swift
@@ -8,10 +8,15 @@
 import UIKit
 import Then
 import SnapKit
+import RxSwift
+import RxCocoa
 
-class StarDeleteAlertViewController: UIViewController {
+final class StarDeleteAlertViewController: UIViewController {
     
     // MARK: - UI 컴포넌트
+    
+    private let viewModel: StarDeleteAlertViewModel
+    private let disposeBag = DisposeBag()
     
     // 모달뷰
     private let modalView = UIView().then {
@@ -73,10 +78,20 @@ class StarDeleteAlertViewController: UIViewController {
     
     // MARK: - 생명주기 메서드
     
+    init(viewModel: StarDeleteAlertViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
         setupAction()
+        bind()
     }
     
     // MARK: - 레이아웃 설정
@@ -142,5 +157,17 @@ class StarDeleteAlertViewController: UIViewController {
     // 모달 닫기
     private func closeModal() {
         dismiss(animated: true)
+    }
+}
+
+// MARK: - bind
+
+extension StarDeleteAlertViewController {
+    
+    private func bind() {
+        let input = StarDeleteAlertViewModel.Input(
+            cancelButtonTapped: cancelButton.rx.tap.asObservable(),
+            deleteButtonTapped: deleteButton.rx.tap.asObservable())
+        viewModel.transform(input)
     }
 }

--- a/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewController.swift
+++ b/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewController.swift
@@ -153,17 +153,10 @@ extension StarDeleteAlertViewController {
             deleteButtonTapped: deleteButton.rx.tap.asObservable())
         viewModel.transform(input)
         
-        // 취소 버튼 이벤트 처리
-        cancelButton.rx.tap
-            .asDriver()
-            .drive(with: self, onNext: { owner, _ in
-                owner.closeModal()
-            })
-            .disposed(by: disposeBag)
-        
-        // 취소 버튼 이벤트 처리
-        deleteButton.rx.tap
-            .asDriver()
+        // 취소버튼, 삭제버튼 이벤트 처리
+        Driver<Void>
+            .merge(cancelButton.rx.tap.asDriver(),
+                   deleteButton.rx.tap.asDriver())
             .drive(with: self, onNext: { owner, _ in
                 owner.closeModal()
             })

--- a/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewController.swift
+++ b/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewController.swift
@@ -90,7 +90,6 @@ final class StarDeleteAlertViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        setupAction()
         bind()
     }
     
@@ -142,22 +141,6 @@ final class StarDeleteAlertViewController: UIViewController {
             $0.height.equalTo(44)
         }
     }
-    
-    // 액션 연결
-    private func setupAction() {
-        cancelButton.addAction(UIAction { [weak self] _ in
-            self?.closeModal()
-        }, for: .touchUpInside)
-        
-        deleteButton.addAction(UIAction { [weak self] _ in
-            self?.closeModal()
-        }, for: .touchUpInside)
-    }
-    
-    // 모달 닫기
-    private func closeModal() {
-        dismiss(animated: true)
-    }
 }
 
 // MARK: - bind
@@ -169,5 +152,26 @@ extension StarDeleteAlertViewController {
             cancelButtonTapped: cancelButton.rx.tap.asObservable(),
             deleteButtonTapped: deleteButton.rx.tap.asObservable())
         viewModel.transform(input)
+        
+        // 취소 버튼 이벤트 처리
+        cancelButton.rx.tap
+            .asDriver()
+            .drive(with: self, onNext: { owner, _ in
+                owner.closeModal()
+            })
+            .disposed(by: disposeBag)
+        
+        // 취소 버튼 이벤트 처리
+        deleteButton.rx.tap
+            .asDriver()
+            .drive(with: self, onNext: { owner, _ in
+                owner.closeModal()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    // 모달 닫기
+    private func closeModal() {
+        dismiss(animated: false)
     }
 }

--- a/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewModel.swift
+++ b/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewModel.swift
@@ -10,20 +10,22 @@ import RxCocoa
 final class StarDeleteAlertViewModel {
     
     private let star: Star
-    private let CloseAction: PublishRelay<Void>
+    private let closeAction: PublishRelay<Void>
     private let disposeBag = DisposeBag()
     
     init(star: Star, CloseAction: PublishRelay<Void>) {
         self.star = star
-        self.CloseAction = CloseAction
+        self.closeAction = CloseAction
     }
     
-    private func deleteStar() {
+    // 스타 삭제
+    private func performStarDeletion() {
         StarManager.shared.delete(star)
     }
     
-    private func doClose() {
-        CloseAction.accept(())
+    // 종료 방출
+    private func closeAlert() {
+        closeAction.accept(())
     }
 }
 
@@ -37,14 +39,14 @@ extension StarDeleteAlertViewModel {
     func transform(_ input: Input) {
         input.cancelButtonTapped
             .subscribe(onNext: {
-                self.doClose()
+                self.closeAlert()
             })
             .disposed(by: disposeBag)
         
         input.deleteButtonTapped
             .subscribe(onNext: {
-                self.deleteStar()
-                self.doClose()
+                self.performStarDeletion()
+                self.closeAlert()
             })
             .disposed(by: disposeBag)
     }

--- a/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewModel.swift
+++ b/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  StarDeleteAlertViewModel.swift
+//  star
+//
+//  Created by 서문가은 on 2/1/25.
+//
+import RxSwift
+import RxCocoa
+
+final class StarDeleteAlertViewModel {
+    
+    private let star: Star
+    private let CloseAction: PublishRelay<Void>
+    private let disposeBag = DisposeBag()
+    
+    init(star: Star, CloseAction: PublishRelay<Void>) {
+        self.star = star
+        self.CloseAction = CloseAction
+    }
+    
+    private func deleteStar() {
+        StarManager.shared.delete(star)
+    }
+    
+    private func doClose() {
+        CloseAction.accept(())
+    }
+}
+
+extension StarDeleteAlertViewModel {
+    
+    struct Input {
+        let cancelButtonTapped: Observable<Void>
+        let deleteButtonTapped: Observable<Void>
+    }
+    
+    func transform(_ input: Input) {
+        input.cancelButtonTapped
+            .subscribe(onNext: {
+                self.doClose()
+            })
+            .disposed(by: disposeBag)
+        
+        input.deleteButtonTapped
+            .subscribe(onNext: {
+                self.deleteStar()
+                self.doClose()
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewModel.swift
+++ b/star/star/Source/Mun/StarDeleteAlert/StarDeleteAlertViewModel.swift
@@ -10,12 +10,12 @@ import RxCocoa
 final class StarDeleteAlertViewModel {
     
     private let star: Star
-    private let closeAction: PublishRelay<Void>
+    private let refreshRelay: PublishRelay<Void>
     private let disposeBag = DisposeBag()
     
-    init(star: Star, CloseAction: PublishRelay<Void>) {
+    init(star: Star, refreshRelay: PublishRelay<Void>) {
         self.star = star
-        self.closeAction = CloseAction
+        self.refreshRelay = refreshRelay
     }
     
     // 스타 삭제
@@ -25,7 +25,7 @@ final class StarDeleteAlertViewModel {
     
     // 종료 방출
     private func closeAlert() {
-        closeAction.accept(())
+        refreshRelay.accept(())
     }
 }
 

--- a/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
+++ b/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
@@ -73,8 +73,8 @@ extension StarListViewController {
         
         // 스타 바인딩
         output.star
-            .drive(onNext: { star in
-                self.showAlert(star)
+            .drive(with: self, onNext: { owner, star in
+                owner.showAlert(star)
             })
             .disposed(by: disposeBag)
         
@@ -119,7 +119,7 @@ extension StarListViewController {
     
     // 삭제하기 알럿 띄우기
     private func showAlert(_ star: Star) {
-        let starDeleteAlertViewModel = StarDeleteAlertViewModel(star: star, CloseAction: viewModel.refreshRelay)
+        let starDeleteAlertViewModel = StarDeleteAlertViewModel(star: star, refreshRelay: viewModel.refreshRelay)
         let starDeleteAlertViewController = StarDeleteAlertViewController(viewModel: starDeleteAlertViewModel)
         starDeleteAlertViewController.modalPresentationStyle = .overFullScreen
         starDeleteAlertViewController.view.backgroundColor = UIColor.black.withAlphaComponent(0.65)

--- a/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
+++ b/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
@@ -10,12 +10,14 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
-class StarListViewController: UIViewController {
+final class StarListViewController: UIViewController {
     
     // MARK: - UI 컴포넌트
     
     let starListView = StarListView()
     let viewModel = StarListViewModel()
+    
+    let deleteActionSubject = PublishSubject<Int>()
     let disposeBag = DisposeBag()
     
     // MARK: - 생명주기 메서드
@@ -36,9 +38,12 @@ class StarListViewController: UIViewController {
 // MARK: - bind
 
 extension StarListViewController {
+    
     private func bind() {
         let viewWillAppears = rx.methodInvoked(#selector(viewWillAppear)).map { _ in }
-        let input = StarListViewModel.Input(viewWillAppear: viewWillAppears)
+        let input = StarListViewModel.Input(
+            viewWillAppear: viewWillAppears,
+            deleteAction: deleteActionSubject)
         let output = viewModel.transform(input)
 
         // 컬렉션뷰 데이터 바인딩
@@ -54,6 +59,13 @@ extension StarListViewController {
         output.date
             .map { TodayDate.formatDate(date: $0)}
             .drive(starListView.todayDateLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        // 스타 바인딩
+        output.star
+            .drive(onNext: { star in
+                self.showAlert(star)
+            })
             .disposed(by: disposeBag)
         
         // 추가하기 버튼 이벤트 처리
@@ -85,8 +97,7 @@ extension StarListViewController {
                 // 삭제 액션 추가
                 let deleteAction = UIContextualAction(style: .destructive, title: nil) { [weak self] _, _, completionHandler in
                     guard let self = self else { return }
-                    self.showAlert()
-                    completionHandler(false)
+                    deleteActionSubject.onNext(indexPath.item)
                 }
                 
                 deleteAction.image = UIImage(systemName: "trash")
@@ -98,8 +109,9 @@ extension StarListViewController {
     }
     
     // 삭제하기 알럿 띄우기
-    private func showAlert() {
-        let starDeleteAlertViewController = StarDeleteAlertViewController()
+    private func showAlert(_ star: Star) {
+        let starDeleteAlertViewModel = StarDeleteAlertViewModel(star: star, CloseAction: viewModel.refreshRelay)
+        let starDeleteAlertViewController = StarDeleteAlertViewController(viewModel: starDeleteAlertViewModel)
         starDeleteAlertViewController.modalPresentationStyle = .overFullScreen
         starDeleteAlertViewController.view.backgroundColor = UIColor.black.withAlphaComponent(0.65)
         present(starDeleteAlertViewController, animated: true)

--- a/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
+++ b/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
@@ -81,11 +81,10 @@ extension StarListViewController {
         // 추가하기 버튼 이벤트 처리
         starListView.addStarButton.rx.tap
             .asDriver()
-            .drive(onNext: { [weak self] in
-                self?.connectCreateModal()
+            .drive(with: self, onNext: { owner, _ in
+                owner.connectCreateModal()
             })
             .disposed(by: disposeBag)
-        
         
         // 셀 선택 이벤트 처리
         starListView.starListCollectionView.rx.itemSelected
@@ -124,7 +123,7 @@ extension StarListViewController {
         let starDeleteAlertViewController = StarDeleteAlertViewController(viewModel: starDeleteAlertViewModel)
         starDeleteAlertViewController.modalPresentationStyle = .overFullScreen
         starDeleteAlertViewController.view.backgroundColor = UIColor.black.withAlphaComponent(0.65)
-        present(starDeleteAlertViewController, animated: true)
+        present(starDeleteAlertViewController, animated: false)
     }
     
     // 생성하기 모달 연결

--- a/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
+++ b/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
@@ -19,21 +19,16 @@ class StarListViewModel {
 
     // 스타 fetch
     private func fetchStars() {
-        let testData = [MockData.ongingOneHour, MockData.ongingThreeHour, MockData.pendingOneMinute, MockData.pendingTenMinute] // 추후 CoreData로 연동
+        let starData = StarManager.shared.read()
         
-        guard let firstData = testData.first else { return }
+        guard let firstData = starData.first else { return }
         var minTimeStar = firstData.state().interval
-        testData.forEach {
+        starData.forEach {
             // 남은 시간이 가장 임박한 star 저장
             if $0.state().interval < minTimeStar {
                 minTimeStar = $0.state().interval
             }
         }
-        
-//        DispatchQueue.main.asyncAfter(deadline: .now() + minTimeStar) { [weak self] in
-//            guard let self = self else { return }
-//            self.fetchStars()
-//        } 나중에 수정
                 
         // 남은 시간이 0이 되면 데이터 fetch
         Timer.scheduledTimer(withTimeInterval: minTimeStar, repeats: false) { [weak self] _ in
@@ -41,7 +36,7 @@ class StarListViewModel {
             self.fetchStars()
         }
         
-        let sortedData = testData.sorted { $0.state() < $1.state() } // 남은 시간이 짧은 순으로 정렬
+        let sortedData = starData.sorted { $0.state() < $1.state() } // 남은 시간이 짧은 순으로 정렬
         starsRelay.accept(sortedData)
     }
     

--- a/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
+++ b/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
@@ -10,18 +10,23 @@ import RxSwift
 import RxCocoa
  
  // 셀 뷰모델   
-class StarListViewModel {
+final class StarListViewModel {
         
     private let starsRelay = BehaviorRelay<[Star]>(value: [])
     private let dateRelay = PublishRelay<Date>()
     private let starStatus = PublishRelay<StarState>()
+    private let starRelay = PublishRelay<Star>()
+    let refreshRelay = PublishRelay<Void>() // 추후 리팩토링 예정
     private let disposeBag = DisposeBag()
 
     // 스타 fetch
     private func fetchStars() {
         let starData = StarManager.shared.read()
         
-        guard let firstData = starData.first else { return }
+        guard let firstData = starData.first else {
+            starsRelay.accept([])
+            return
+        }
         var minTimeStar = firstData.state().interval
         starData.forEach {
             // 남은 시간이 가장 임박한 star 저장
@@ -44,20 +49,40 @@ class StarListViewModel {
     private func fetchDate() {
         dateRelay.accept(Date.now)
     }
+    
+    private func tappedDeleteButton(_ index: Int) {
+        let stars = starsRelay.value
+        starRelay.accept(stars[index])
+    }
 }
 
 extension StarListViewModel {
     
     struct Input {
         let viewWillAppear: Observable<Void>
+        let deleteAction: PublishSubject<Int>
     }
     
     struct Output {
         let starDataSource: Driver<[Star]>
         let date: Driver<Date>
+        let star: Driver<Star>
+
     }
     
     func transform(_ input: Input) -> Output {
+        refreshRelay
+            .subscribe(onNext: {
+                self.fetchStars()
+            })
+            .disposed(by: disposeBag)
+        
+        input.deleteAction
+            .withUnretained(self)
+            .subscribe(onNext: { owner, index in
+                self.tappedDeleteButton(index)
+            }).disposed(by: disposeBag)
+        
         input.viewWillAppear
             .withUnretained(self)
             .subscribe(onNext:  { _ in
@@ -66,8 +91,7 @@ extension StarListViewModel {
             }).disposed(by: disposeBag)
         
         return Output(starDataSource: starsRelay.asDriver(onErrorJustReturn: []),
-                      date: dateRelay.asDriver(onErrorDriveWith: .empty()))
+                      date: dateRelay.asDriver(onErrorDriveWith: .empty()),
+                      star: starRelay.asDriver(onErrorDriveWith: .empty()))
     }
 }
-
-

--- a/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
+++ b/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
@@ -14,8 +14,8 @@ final class StarListViewModel {
         
     private let starsRelay = BehaviorRelay<[Star]>(value: [])
     private let dateRelay = PublishRelay<Date>()
-    private let starStatus = PublishRelay<StarState>()
-    private let starRelay = PublishRelay<Star>()
+    private let starStatusRelay = PublishRelay<StarState>()
+    private let selectedStarRelay = PublishRelay<Star>() // 삭제 버튼 누르면 방출
     let refreshRelay = PublishRelay<Void>() // 추후 리팩토링 예정
     private let disposeBag = DisposeBag()
 
@@ -50,9 +50,10 @@ final class StarListViewModel {
         dateRelay.accept(Date.now)
     }
     
-    private func tappedDeleteButton(_ index: Int) {
+    // 삭제 버튼 누르면 스타 방출
+    private func emitSelectedStar(_ index: Int) {
         let stars = starsRelay.value
-        starRelay.accept(stars[index])
+        selectedStarRelay.accept(stars[index])
     }
 }
 
@@ -80,7 +81,7 @@ extension StarListViewModel {
         input.deleteAction
             .withUnretained(self)
             .subscribe(onNext: { owner, index in
-                self.tappedDeleteButton(index)
+                self.emitSelectedStar(index)
             }).disposed(by: disposeBag)
         
         input.viewWillAppear
@@ -92,6 +93,6 @@ extension StarListViewModel {
         
         return Output(starDataSource: starsRelay.asDriver(onErrorJustReturn: []),
                       date: dateRelay.asDriver(onErrorDriveWith: .empty()),
-                      star: starRelay.asDriver(onErrorDriveWith: .empty()))
+                      star: selectedStarRelay.asDriver(onErrorDriveWith: .empty()))
     }
 }

--- a/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
+++ b/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
@@ -73,7 +73,8 @@ extension StarListViewModel {
     
     func transform(_ input: Input) -> Output {
         refreshRelay
-            .subscribe(onNext: {
+            .withUnretained(self)
+            .subscribe(onNext: { _ in
                 self.fetchStars()
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## #️⃣ Issue Number

#83 

## 📝 요약(Summary)

스타리스트 화면에 CoreData를 연결하여 데이터를 불러오고 삭제하는 기능을 구현했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

![Simulator Screen Recording - iPhone 16 Pro - 2025-02-02 at 20 45 57](https://github.com/user-attachments/assets/e6fcffe4-fb88-44d6-97aa-be07148295b9)


## 💬 공유사항 to 리뷰어

- StarListViewModel
  -  `refreshRelay`를 `StarDeleteAlertViewModel`에 전달
  - `StarDeleteAlertViewController`에서 삭제 버튼을 누르면 릴레이를 방출하고 `star` 데이터 `fetch`
  - 추후 생성하기, 수정하기 모달과도 연결하여 사용할 예정
  - 코드 개선 필요 → 다음 리팩토링때 수정 예정 

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
