### PR TITLE
스타 생성/수정 모달 모드 전환 기능 구현

### DIFF
--- a/star/star/Source/Glass/StarModalView.swift
+++ b/star/star/Source/Glass/StarModalView.swift
@@ -90,7 +90,6 @@ final class StarModalView: UIView {
         button.applyGradient(colors: [.starButtonPurple, .starButtonNavy], direction: .horizontal)
         button.gradientLayer.isHidden = true
         button.backgroundColor = .starDisabledTagBG // 그라디언트가 정상적으로 적용될 시 배경색은 보이지 않음
-        //button.tag = 0 //버튼 활성화 여부 체크시 사용. 0 -> 클릭(X), 1 -> 클릭(O)
         return button
     }
     
@@ -310,8 +309,6 @@ final class StarModalView: UIView {
             $0.height.equalTo(56)
             $0.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
         }
-        
-        //addStarButton.applyGradient(colors: [.starButtonPurple, .starButtonNavy], direction: .horizontal)
     }
 }
 

--- a/star/star/Source/Glass/StarModalView.swift
+++ b/star/star/Source/Glass/StarModalView.swift
@@ -87,8 +87,10 @@ final class StarModalView: UIView {
         button.titleLabel?.font = Fonts.modalDayOption
         button.layer.cornerRadius = 18
         button.clipsToBounds = true
+        button.applyGradient(colors: [.starButtonPurple, .starButtonNavy], direction: .horizontal)
+        button.gradientLayer.isHidden = true
         button.backgroundColor = .starDisabledTagBG // 그라디언트가 정상적으로 적용될 시 배경색은 보이지 않음
-        button.tag = 0 //버튼 활성화 여부 체크시 사용. 0 -> 클릭(X), 1 -> 클릭(O)
+        //button.tag = 0 //버튼 활성화 여부 체크시 사용. 0 -> 클릭(X), 1 -> 클릭(O)
         return button
     }
     
@@ -308,8 +310,55 @@ final class StarModalView: UIView {
             $0.height.equalTo(56)
             $0.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
         }
+        
+        //addStarButton.applyGradient(colors: [.starButtonPurple, .starButtonNavy], direction: .horizontal)
     }
 }
+
+// MARK: - 데이터 설정
+
+extension StarModalView {
+    
+    func configure(star: Star) {
+        titleLabel.text = "스타 수정"
+        addStarButton.setTitle("수정하기", for: .normal)
+        nameTextField.text = star.title
+        
+        let starTime = star.schedule.startTime.coreDataForm()
+        let finishTime = star.schedule.finishTime.coreDataForm()
+        startTimeButton.setTitle(starTime, for: .normal)
+        endTimeButton.setTitle(finishTime, for: .normal)
+
+        if star.schedule.weekDays.contains(WeekDay.mon) {
+            mondayButton.gradientLayer.isHidden = false
+        }
+        
+        if star.schedule.weekDays.contains(WeekDay.tue) {
+            tuesdayButton.gradientLayer.isHidden = false
+        }
+        
+        if star.schedule.weekDays.contains(WeekDay.wed) {
+            wednesdayButton.gradientLayer.isHidden = false
+        }
+        
+        if star.schedule.weekDays.contains(WeekDay.thu) {
+            thursdayButton.gradientLayer.isHidden = false
+        }
+        
+        if star.schedule.weekDays.contains(WeekDay.fri) {
+            fridayButton.gradientLayer.isHidden = false
+        }
+        
+        if star.schedule.weekDays.contains(WeekDay.sat) {
+            saturdayButton.gradientLayer.isHidden = false
+        }
+        
+        if star.schedule.weekDays.contains(WeekDay.sun) {
+            sundayButton.gradientLayer.isHidden = false
+        }
+    }
+}
+
 
 // MARK: - 텍스트필드 삭제 버튼
 private extension UITextField {

--- a/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
+++ b/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
@@ -82,14 +82,15 @@ extension StarListViewController {
         starListView.addStarButton.rx.tap
             .asDriver()
             .drive(with: self, onNext: { owner, _ in
-                owner.connectCreateModal()
+                owner.connectCreateModal(mode: .create)
             })
             .disposed(by: disposeBag)
         
         // 셀 선택 이벤트 처리
-        starListView.starListCollectionView.rx.itemSelected
-            .subscribe(onNext: { _ in
-                print("셀 클릭")
+        starListView.starListCollectionView.rx.modelSelected(Star.self)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, star in
+                self.connectCreateModal(mode: .edit(star: star))
             })
             .disposed(by: disposeBag)
     }
@@ -127,8 +128,9 @@ extension StarListViewController {
     }
     
     // 생성하기 모달 연결
-    private func connectCreateModal() {
-        let modalVC = StarModalViewController()
+    private func connectCreateModal(mode: Mode) {
+        let modalViewModel = StarModalViewModel(mode: mode, refreshRelay: viewModel.refreshRelay)
+        let modalVC = StarModalViewController(viewModel: modalViewModel)
         modalVC.sheetPresentationController?.detents = [.custom(resolver: { context in
             let modalHeight = UIScreen.main.bounds.size.height - self.starListView.topView.frame.maxY - self.view.safeAreaInsets.bottom - 4
             return modalHeight


### PR DESCRIPTION
## #️⃣ Issue Number

#21

## 📝 요약(Summary)

스타 모달 뷰의 생성하기 수정하기 모드를 구현했습니다. 스타 리스트 화면에서 셀을 클릭하면 수정하기, 추가하기 버튼을 누르면 생성하기 모드로 연결됩니다. 

@AhnJunGyung 
`ViewModel`의 `transform` 메서드에서 `edit`일 경우 임의로 코어데이터가 `update` 되도록 변경하였습니다. 추후 완전한 데이터 저장이 필요합니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

![Simulator Screen Recording - iPhone 16 Pro - 2025-02-03 at 16 04 00](https://github.com/user-attachments/assets/120b200e-ba35-45a7-8575-dec0e2bcf1bd)

## 💬 공유사항 to 리뷰어
- `Mode` 구조체 정의
  - `create`, `edit` 을 사용하여 `viewModel`을 초기화합니다. 
 
- 글라쓰 코드라 다른 부분은 수정하지 않았습니다. 새로 작성된 부분에 대해서만 리뷰 부탁드립니다. 

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
