### PR TITLE
타이머용 폰트 변경

### DIFF
--- a/star/star/Source/Core/Theme/Fonts.swift
+++ b/star/star/Source/Core/Theme/Fonts.swift
@@ -21,7 +21,7 @@ struct Fonts {
     /// 스타의 이름  / size : 20 / semibold
     static let starTitle = UIFont.systemFont(ofSize: 20, weight: .semibold)
     /// 스타의 남은 시간 / size : 14 / semibold
-    static let starTime = UIFont.systemFont(ofSize: 14, weight: .semibold)
+    static let starTime = UIFont.monospacedDigitSystemFont(ofSize: 14, weight: .semibold)
     /// 스타의 태그  / size : 14 / semibold
     static let starTag = UIFont.systemFont(ofSize: 14, weight: .semibold)
     


### PR DESCRIPTION
## #️⃣ Issue Number

#93 

## 📝 요약(Summary)

남은 시간을 보여주는 `starTime`의 폰트를 타이머용 폰트로 변경했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)
![Simulator Screen Recording - iPhone 16 Pro - 2025-02-03 at 23 03 05](https://github.com/user-attachments/assets/56866d47-bac8-42be-85b1-b397d0e26a73)

## 💬 공유사항 to 리뷰어

- `starTime` 폰트 변경
  - 폰트를 `monospacedDigitSystemFont`로 변경하여, 값이 변해도 라벨의 위치가 변하지 않습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
