### PR TITLE
휴식 화면 플로우에 사용되는 Color Assets 추가

### DIFF
--- a/star/star/Resource/Colors.xcassets/starAlertModalOverlayBG.colorset/Contents.json
+++ b/star/star/Resource/Colors.xcassets/starAlertModalOverlayBG.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.650",
+          "blue" : "0",
+          "green" : "0",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/star/star/Resource/Colors.xcassets/starButtonGray.colorset/Contents.json
+++ b/star/star/Resource/Colors.xcassets/starButtonGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "80",
+          "green" : "80",
+          "red" : "80"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/star/star/Resource/Colors.xcassets/starButtonWhite.colorset/Contents.json
+++ b/star/star/Resource/Colors.xcassets/starButtonWhite.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xF8",
+          "red" : "0xF8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/star/star/Resource/Colors.xcassets/starButtonYellow.colorset/Contents.json
+++ b/star/star/Resource/Colors.xcassets/starButtonYellow.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "74",
+          "green" : "205",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/star/star/Resource/Colors.xcassets/starModalOverlayBG.colorset/Contents.json
+++ b/star/star/Resource/Colors.xcassets/starModalOverlayBG.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.900",
+          "blue" : "0x19",
+          "green" : "0x05",
+          "red" : "0x0E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#115 

## 📝 요약(Summary)

휴식 화면 플로우에 사용되는 Color Assets 추가
- `starButtonWhite`와 `starButtonYellow`: 휴식 관련 버튼에 사용되는 색
- `starButtonGray`: 취소하기 버튼에 사용되는 색
- `starModalOverlayBG`: 휴식 모든 플로우 모달에 사용되는 오버레이 배경 색
- `starAlertModalOverlayBG`: 삭제 알럿 모달에 사용되는 오버레이 배경 색

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항 to 리뷰어
요약에 정리해두었습니다. 확인하시고 사용해주세요!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
