### PR TITLE
휴식 진입 화면 UI 구현

### DIFF
--- a/star/star/Source/Mun/RestStartView.swift
+++ b/star/star/Source/Mun/RestStartView.swift
@@ -1,0 +1,115 @@
+//
+//  RestStartView.swift
+//  star
+//
+//  Created by 서문가은 on 2/10/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class RestStartView: UIView {
+    
+    // MARK: - UI Components
+    
+    // 타이틀 라벨
+    private let titleLabel = UILabel().then {
+        $0.text = "휴식 모드 전환"
+        $0.font = .systemFont(ofSize: 24, weight: .semibold)
+        $0.textAlignment = .center
+        $0.textColor = .starButtonWhite
+    }
+    
+    // 설명 라벨
+    private let descriptionLabel = UILabel().then {
+        $0.text = """
+당신을 빛나게 하는 시간은
+스스로 선택할 때 더욱 빛나요.
+"""
+        $0.numberOfLines = 2
+        $0.font = Fonts.starTitle
+        $0.font = .systemFont(ofSize: 16, weight: .regular)
+        $0.textAlignment = .center
+        $0.textColor = .starButtonWhite
+    }
+    
+    // 시간 테두리 뷰
+    private let timeView = UIView().then {
+        $0.layer.cornerRadius = 180 / 2
+        $0.clipsToBounds = true
+        $0.layer.borderWidth = 8
+        $0.layer.borderColor = UIColor.starButtonYellow.cgColor
+    }
+    
+    // 시간 라벨
+    private let timeLabel = UILabel().then {
+        $0.text = "5"
+        $0.font = .monospacedSystemFont(ofSize: 32, weight: .regular)
+        $0.textAlignment = .center
+        $0.textColor = .starButtonWhite
+    }
+    
+    // 취소 버튼
+    let cancelButton = GradientButton(type: .system).then {
+            $0.setTitle("취소하기", for: .normal)
+            $0.setTitleColor(.starPrimaryText, for: .normal)
+            $0.titleLabel?.font = Fonts.buttonTitle
+            $0.backgroundColor = .starDisabledTagBG
+            $0.layer.cornerRadius = 28
+            $0.clipsToBounds = true
+        }
+    
+    // MARK: - 초기화
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - 레이아웃 설정
+    
+    private func setupUI() {
+        [
+            titleLabel,
+            descriptionLabel,
+            timeView,
+            cancelButton
+        ].forEach {
+            addSubviews($0)
+        }
+        
+        timeView.addSubview(timeLabel)
+        
+        titleLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(descriptionLabel.snp.top).offset(-12)
+        }
+        
+        descriptionLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview().offset(-100)
+            $0.centerX.equalToSuperview()
+        }
+        
+        timeView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(40)
+            $0.width.height.equalTo(180)
+        }
+        
+        timeLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        cancelButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).offset(-16)
+            $0.height.equalTo(56)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
+}

--- a/star/star/Source/Mun/RestStartViewController.swift
+++ b/star/star/Source/Mun/RestStartViewController.swift
@@ -1,0 +1,19 @@
+//
+//  RestStartViewController.swift
+//  star
+//
+//  Created by 서문가은 on 2/10/25.
+//
+
+import UIKit
+
+class RestStartViewController: UIViewController {
+    
+    override func loadView() {
+        view = RestStartView()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/star/star/Source/Mun/StarList/StarListView/StarListView.swift
+++ b/star/star/Source/Mun/StarList/StarListView/StarListView.swift
@@ -36,6 +36,14 @@ class StarListView: UIView {
         $0.font = Fonts.todayDate
     }
     
+    // 휴식 버튼
+    let restButton = UIButton(type: .system).then {
+        $0.setTitle("OFF", for: .normal)
+        $0.setTitleColor(.starButtonWhite, for: .normal)
+        $0.setImage(UIImage(systemName: "cup.and.saucer.fill"), for: .normal)
+        $0.tintColor = .starButtonWhite
+    }
+    
     // 시작하기 버튼
     let addStarButton = GradientButton(type: .system).then {
             $0.setTitle("스타 추가하기", for: .normal)
@@ -69,6 +77,7 @@ class StarListView: UIView {
         [
             topView,
             starListCollectionView,
+            restButton,
             addStarButton
         ].forEach { addSubview($0) }
         
@@ -108,6 +117,11 @@ class StarListView: UIView {
             $0.top.equalTo(topView.snp.bottom).offset(32)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(addStarButton.snp.top).offset(-32)
+        }
+        
+        restButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalTo(topView.snp.centerY)
         }
         
         addStarButton.snp.makeConstraints {

--- a/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
+++ b/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
@@ -30,12 +30,11 @@ final class StarListViewController: UIViewController {
         super.viewDidLoad()
         bind()
         setupSwipeActions()
-        
-        navigationItem.hidesBackButton = true
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.navigationController?.navigationBar.isHidden = true
         // 온보딩 뷰를 보여주지 않았다면 온보딩뷰 표시
         if !UserDefaults.standard.isCoachMarkShown {
             let onboardingViewController = OnboardingViewController()
@@ -75,6 +74,14 @@ extension StarListViewController {
         output.star
             .drive(with: self, onNext: { owner, star in
                 owner.showAlert(star)
+            })
+            .disposed(by: disposeBag)
+        
+        // 휴식 버튼 이벤트 처리
+        starListView.restButton.rx.tap
+            .asDriver()
+            .drive(with: self, onNext: { owner, _ in
+                owner.connectRestModal()
             })
             .disposed(by: disposeBag)
         
@@ -125,6 +132,14 @@ extension StarListViewController {
         starDeleteAlertViewController.modalPresentationStyle = .overFullScreen
         starDeleteAlertViewController.view.backgroundColor = .starModalOverlayBG
         present(starDeleteAlertViewController, animated: false)
+    }
+    
+    // 휴식 화면 모달 연결
+    private func connectRestModal() {
+        let restStartViewController = RestStartViewController()
+        restStartViewController.view.backgroundColor = .starModalOverlayBG
+        restStartViewController.modalPresentationStyle = .overFullScreen
+        present(restStartViewController, animated: true)
     }
     
     // 생성하기 모달 연결


### PR DESCRIPTION
## #️⃣ Issue Number

#125 

## 📝 요약(Summary)

스타 리스트 화면에서 휴식 아이콘을 누르면 휴식 진입 화면으로 이어지는 UI를 구현했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

![Simulator Screenshot - iPhone 16 Pro - 2025-02-10 at 17 37 17](https://github.com/user-attachments/assets/225cdb33-c6a5-44a6-b868-afe32f4c38a6)

## 💬 공유사항 to 리뷰어

- 스타리스트 화면의 휴식 아이콘과 라벨은 연결 확인을 위해 임의로 설정한 것으로, 추후 수정할 계획입니다. 
- 휴식 진입 화면에서 사용되는 폰트도 `Fonts`에서 정의하여 사용할 계획입니다. 

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
