### PR TITLE
휴식 진입 화면 카운트다운 기능 구현

### DIFF
--- a/star/star/Source/Mun/RestStartView.swift
+++ b/star/star/Source/Mun/RestStartView.swift
@@ -43,7 +43,7 @@ class RestStartView: UIView {
     }
     
     // 시간 라벨
-    private let timeLabel = UILabel().then {
+    let timeLabel = UILabel().then {
         $0.text = "5"
         $0.font = .monospacedSystemFont(ofSize: 32, weight: .regular)
         $0.textAlignment = .center

--- a/star/star/Source/Mun/RestStartView.swift
+++ b/star/star/Source/Mun/RestStartView.swift
@@ -34,16 +34,16 @@ class RestStartView: UIView {
         $0.textColor = .starButtonWhite
     }
     
-    // 시간 테두리 뷰
-    private let timeView = UIView().then {
+    // 카운트 테두리 뷰
+    private let countView = UIView().then {
         $0.layer.cornerRadius = 180 / 2
         $0.clipsToBounds = true
         $0.layer.borderWidth = 8
         $0.layer.borderColor = UIColor.starButtonYellow.cgColor
     }
     
-    // 시간 라벨
-    let timeLabel = UILabel().then {
+    // 카운트 라벨
+    let countLabel = UILabel().then {
         $0.text = "5"
         $0.font = .monospacedSystemFont(ofSize: 32, weight: .regular)
         $0.textAlignment = .center
@@ -77,13 +77,13 @@ class RestStartView: UIView {
         [
             titleLabel,
             descriptionLabel,
-            timeView,
+            countView,
             cancelButton
         ].forEach {
             addSubviews($0)
         }
         
-        timeView.addSubview(timeLabel)
+        countView.addSubview(countLabel)
         
         titleLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
@@ -95,13 +95,13 @@ class RestStartView: UIView {
             $0.centerX.equalToSuperview()
         }
         
-        timeView.snp.makeConstraints {
+        countView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(descriptionLabel.snp.bottom).offset(40)
             $0.width.height.equalTo(180)
         }
         
-        timeLabel.snp.makeConstraints {
+        countLabel.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
         

--- a/star/star/Source/Mun/RestStartView.swift
+++ b/star/star/Source/Mun/RestStartView.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-class RestStartView: UIView {
+final class RestStartView: UIView {
     
     // MARK: - UI Components
     

--- a/star/star/Source/Mun/RestStartViewController.swift
+++ b/star/star/Source/Mun/RestStartViewController.swift
@@ -42,10 +42,8 @@ final class RestStartViewController: UIViewController {
         // 카운트 바인딩
         output.count
             .do(onNext: { [weak self] count in
-                if count == 0 {
-                    guard let self = self else { return }
-                    self.connectRestSettingModal()
-                }
+                guard let self, count == 0 else { return }
+                self.connectRestSettingModal()
             })
             .filter({ count in
                 count != 0

--- a/star/star/Source/Mun/RestStartViewController.swift
+++ b/star/star/Source/Mun/RestStartViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-class RestStartViewController: UIViewController {
+final class RestStartViewController: UIViewController {
     
     private let restStartView = RestStartView()
     private let restStartViewModel = RestStartViewModel()

--- a/star/star/Source/Mun/RestStartViewController.swift
+++ b/star/star/Source/Mun/RestStartViewController.swift
@@ -48,7 +48,7 @@ class RestStartViewController: UIViewController {
                 }
             })
             .map { "\($0)"}
-            .drive(restStartView.timeLabel.rx.text)
+            .drive(restStartView.countLabel.rx.text)
             .disposed(by: disposeBag)
     }
 }

--- a/star/star/Source/Mun/RestStartViewController.swift
+++ b/star/star/Source/Mun/RestStartViewController.swift
@@ -41,15 +41,18 @@ final class RestStartViewController: UIViewController {
         
         // 카운트 바인딩
         output.count
-            .do(onNext: { [weak self] count in
-                guard let self, count == 0 else { return }
-                self.connectRestSettingModal()
-            })
             .filter({ count in
                 count != 0
             })
             .map { "\($0)"}
             .drive(restStartView.countLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        // 완료 바인딩
+        output.complete
+            .drive(with: self, onNext: { owner, _ in
+                owner.connectRestSettingModal()
+            })
             .disposed(by: disposeBag)
     }
 }

--- a/star/star/Source/Mun/RestStartViewController.swift
+++ b/star/star/Source/Mun/RestStartViewController.swift
@@ -6,14 +6,62 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
 class RestStartViewController: UIViewController {
     
+    private let restStartView = RestStartView()
+    private let restStartViewModel = RestStartViewModel()
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - 생명주기 메서드
+    
     override func loadView() {
-        view = RestStartView()
+        view = restStartView
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        bind()
+    }
+    
+    // MARK: - bind
+    
+    private func bind() {
+        // 취소버튼 이벤트 처리
+        restStartView.cancelButton.rx.tap
+            .asDriver()
+            .drive(with: self, onNext: { owner, _ in
+                owner.closeModal()
+            })
+            .disposed(by: disposeBag)
+        
+        let output = restStartViewModel.transform()
+        
+        // 카운트 바인딩
+        output.count
+            .do(onNext: { [weak self] count in
+                if count == 0 {
+                    guard let self = self else { return }
+                    self.connectRestSettingModal()
+                }
+            })
+            .map { "\($0)"}
+            .drive(restStartView.timeLabel.rx.text)
+            .disposed(by: disposeBag)
+    }
+}
+
+extension RestStartViewController {
+    
+    // 모달 종료
+    private func closeModal() {
+        dismiss(animated: true)
+    }
+    
+    // 휴식 설정 모달 연결
+    private func connectRestSettingModal() {
+        dismiss(animated: true) // 임의 연결, 휴식 설정 모달과 연결 예정
     }
 }

--- a/star/star/Source/Mun/RestStartViewController.swift
+++ b/star/star/Source/Mun/RestStartViewController.swift
@@ -47,6 +47,9 @@ class RestStartViewController: UIViewController {
                     self.connectRestSettingModal()
                 }
             })
+            .filter({ count in
+                count != 0
+            })
             .map { "\($0)"}
             .drive(restStartView.countLabel.rx.text)
             .disposed(by: disposeBag)

--- a/star/star/Source/Mun/RestStartViewModel.swift
+++ b/star/star/Source/Mun/RestStartViewModel.swift
@@ -12,6 +12,7 @@ import RxCocoa
 final class RestStartViewModel {
     
     private let countRelay = BehaviorRelay(value: 5)
+    private let completeRelay = PublishRelay<Void>()
     private let disposeBag = DisposeBag()
     
     // 5초 카운트다운 실행
@@ -21,8 +22,10 @@ final class RestStartViewModel {
                               scheduler: MainScheduler.instance)
             .withUnretained(self)
             .take(5) // 5번만 실행
-            .subscribe(onNext: { owner, _ in
+            .subscribe(onNext: { owner, count in
                 owner.countRelay.accept(owner.countRelay.value - 1) // 1씩 감소
+            }, onCompleted: {
+                self.completeRelay.accept(())
             })
             .disposed(by: disposeBag)
     }
@@ -32,10 +35,14 @@ extension RestStartViewModel {
     
     struct Output {
         let count: Driver<Int>
+        let complete: Driver<Void>
     }
     
     func transform() -> Output {
         startCountdown()
-        return Output(count: countRelay.asDriver(onErrorDriveWith: .empty()))
+        return Output(
+            count: countRelay.asDriver(onErrorDriveWith: .empty()),
+            complete: completeRelay.asDriver(onErrorDriveWith: .empty())
+        )
     }
 }

--- a/star/star/Source/Mun/RestStartViewModel.swift
+++ b/star/star/Source/Mun/RestStartViewModel.swift
@@ -16,7 +16,9 @@ final class RestStartViewModel {
     
     // 5초 카운트다운 실행
     private func startCountdown() {
-        Observable<Int>.timer(.seconds(1), period: .seconds(1), scheduler: MainScheduler.instance)
+        Observable<Int>.timer(.seconds(1),
+                              period: .seconds(1),
+                              scheduler: MainScheduler.instance)
             .withUnretained(self)
             .take(5) // 5번만 실행
             .subscribe(onNext: { owner, _ in

--- a/star/star/Source/Mun/RestStartViewModel.swift
+++ b/star/star/Source/Mun/RestStartViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  RestStartViewModel.swift
+//  star
+//
+//  Created by 서문가은 on 2/10/25.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+final class RestStartViewModel {
+    
+    private let countRelay = BehaviorRelay(value: 5)
+    private let disposeBag = DisposeBag()
+    
+    // 5초 카운트다운 실행
+    private func startCountdown() {
+        Observable<Int>.timer(.seconds(1), period: .seconds(1), scheduler: MainScheduler.instance)
+            .withUnretained(self)
+            .take(5) // 5번만 실행
+            .subscribe(onNext: { owner, _ in
+                owner.countRelay.accept(owner.countRelay.value - 1) // 1씩 감소
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+extension RestStartViewModel {
+    
+    struct Output {
+        let count: Driver<Int>
+    }
+    
+    func transform() -> Output {
+        startCountdown()
+        return Output(count: countRelay.asDriver(onErrorDriveWith: .empty()))
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#127 

## 📝 요약(Summary)

휴식 진입 화면 카운트다운 기능과 취소하기를 누르면 모달이 종료되는 기능을 구현했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)
![Simulator Screen Recording - iPhone 16 Pro - 2025-02-10 at 20 28 39](https://github.com/user-attachments/assets/22055038-34ff-47f8-bbb1-5ce66daf89f2)

## 💬 공유사항 to 리뷰어

- 현재는 0초가 되면 모달이 종료되게 설정되어 있지만, 휴식 설정 화면으로 연결할 예정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
