### PR TITLE
휴식 설정 화면 연결 기능 구현

### DIFF
--- a/star/star/Source/Mun/RestStartViewController.swift
+++ b/star/star/Source/Mun/RestStartViewController.swift
@@ -12,8 +12,7 @@ import RxCocoa
 final class RestStartViewController: UIViewController {
     
     private let restStartView = RestStartView()
-    let restStartViewModel: RestStartViewModel
-    //let rest
+    private let restStartViewModel: RestStartViewModel
     private let disposeBag = DisposeBag()
     
     // MARK: - 생명주기 메서드

--- a/star/star/Source/Mun/RestStartViewController.swift
+++ b/star/star/Source/Mun/RestStartViewController.swift
@@ -12,10 +12,20 @@ import RxCocoa
 final class RestStartViewController: UIViewController {
     
     private let restStartView = RestStartView()
-    private let restStartViewModel = RestStartViewModel()
+    let restStartViewModel: RestStartViewModel
+    //let rest
     private let disposeBag = DisposeBag()
     
     // MARK: - 생명주기 메서드
+    
+    init(restStartViewModel: RestStartViewModel) {
+        self.restStartViewModel = restStartViewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func loadView() {
         view = restStartView
@@ -29,14 +39,6 @@ final class RestStartViewController: UIViewController {
     // MARK: - bind
     
     private func bind() {
-        // 취소버튼 이벤트 처리
-        restStartView.cancelButton.rx.tap
-            .asDriver()
-            .drive(with: self, onNext: { owner, _ in
-                owner.closeModal()
-            })
-            .disposed(by: disposeBag)
-        
         let output = restStartViewModel.transform()
         
         // 카운트 바인딩
@@ -44,28 +46,24 @@ final class RestStartViewController: UIViewController {
             .filter({ count in
                 count != 0
             })
-            .map { "\($0)"}
+            .map { "\($0)" }
             .drive(restStartView.countLabel.rx.text)
             .disposed(by: disposeBag)
         
         // 완료 바인딩
         output.complete
             .drive(with: self, onNext: { owner, _ in
-                owner.connectRestSettingModal()
+                owner.dismiss(animated: true)
+                owner.restStartViewModel.restStartCompleteRelay.accept(())
             })
             .disposed(by: disposeBag)
-    }
-}
-
-extension RestStartViewController {
-    
-    // 모달 종료
-    private func closeModal() {
-        dismiss(animated: true)
-    }
-    
-    // 휴식 설정 모달 연결
-    private func connectRestSettingModal() {
-        dismiss(animated: true) // 임의 연결, 휴식 설정 모달과 연결 예정
+        
+        // 취소버튼 이벤트 처리
+        restStartView.cancelButton.rx.tap
+            .asDriver()
+            .drive(with: self, onNext: { owner, _ in
+                owner.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/star/star/Source/Mun/RestStartViewModel.swift
+++ b/star/star/Source/Mun/RestStartViewModel.swift
@@ -38,7 +38,6 @@ final class RestStartViewModel {
 
 extension RestStartViewModel {
 
-    
     struct Output {
         let count: Driver<Int>
         let complete: Driver<Void>

--- a/star/star/Source/Mun/RestStartViewModel.swift
+++ b/star/star/Source/Mun/RestStartViewModel.swift
@@ -13,7 +13,12 @@ final class RestStartViewModel {
     
     private let countRelay = BehaviorRelay(value: 5)
     private let completeRelay = PublishRelay<Void>()
+    let restStartCompleteRelay: PublishRelay<Void> // 휴식 진입 화면 완료 릴레이 -> 메인 화면에서 이벤트 방출 받음
     private let disposeBag = DisposeBag()
+    
+    init(restStartCompleteRelay: PublishRelay<Void>) {
+        self.restStartCompleteRelay = restStartCompleteRelay
+    }
     
     // 5초 카운트다운 실행
     private func startCountdown() {
@@ -32,6 +37,7 @@ final class RestStartViewModel {
 }
 
 extension RestStartViewModel {
+
     
     struct Output {
         let count: Driver<Int>
@@ -40,6 +46,7 @@ extension RestStartViewModel {
     
     func transform() -> Output {
         startCountdown()
+
         return Output(
             count: countRelay.asDriver(onErrorDriveWith: .empty()),
             complete: completeRelay.asDriver(onErrorDriveWith: .empty())

--- a/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
+++ b/star/star/Source/Mun/StarList/StarListView/StarListViewController.swift
@@ -77,11 +77,17 @@ extension StarListViewController {
             })
             .disposed(by: disposeBag)
         
+        output.restStartComplete
+            .drive(with: self, onNext: { owner, _ in
+                owner.connectRestSettingModal()
+            })
+            .disposed(by: disposeBag)
+        
         // 휴식 버튼 이벤트 처리
         starListView.restButton.rx.tap
             .asDriver()
             .drive(with: self, onNext: { owner, _ in
-                owner.connectRestModal()
+                owner.connectRestStartModal()
             })
             .disposed(by: disposeBag)
         
@@ -134,12 +140,36 @@ extension StarListViewController {
         present(starDeleteAlertViewController, animated: false)
     }
     
-    // 휴식 화면 모달 연결
-    private func connectRestModal() {
-        let restStartViewController = RestStartViewController()
+    // 휴식 진입 화면 모달 연결
+    private func connectRestStartModal() {
+        let restStartViewModel = RestStartViewModel(restStartCompleteRelay: viewModel.restStartCompleteRelay)
+        let restStartViewController = RestStartViewController(restStartViewModel: restStartViewModel)
         restStartViewController.view.backgroundColor = .starModalOverlayBG
         restStartViewController.modalPresentationStyle = .overFullScreen
         present(restStartViewController, animated: true)
+    }
+    
+    // 휴식 설정 화면 모달 연결
+    private func connectRestSettingModal() {
+        let restSettingModalViewController = RestSettingModalViewController()
+        restSettingModalViewController.modalPresentationStyle = .pageSheet
+        restSettingModalViewController.sheetPresentationController?.prefersGrabberVisible = true
+        
+        // 모달 화면 높이 설정
+        if let sheet = restSettingModalViewController.sheetPresentationController {
+            if #available(iOS 16.0, *) {
+                sheet.detents = [
+                    .custom { _ in
+                        return 350
+                    }
+                ]
+            } else {
+                sheet.detents = [.medium()]
+            }
+        }
+        
+        restSettingModalViewController.view.layer.cornerRadius = 40
+        present(restSettingModalViewController, animated: true)
     }
     
     // 생성하기 모달 연결

--- a/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
+++ b/star/star/Source/Mun/StarList/StarListViewModel/StarListViewModel.swift
@@ -17,6 +17,7 @@ final class StarListViewModel {
     private let starStatusRelay = PublishRelay<StarState>()
     private let selectedStarRelay = PublishRelay<Star>() // 삭제 버튼 누르면 방출
     let refreshRelay = PublishRelay<Void>() // 추후 리팩토링 예정
+    let restStartCompleteRelay = PublishRelay<Void>()
     private let disposeBag = DisposeBag()
 
     // 스타 fetch
@@ -77,7 +78,7 @@ extension StarListViewModel {
         let starDataSource: Driver<[Star]>
         let date: Driver<Date>
         let star: Driver<Star>
-
+        let restStartComplete: Driver<Void>
     }
     
     func transform(_ input: Input) -> Output {
@@ -103,6 +104,7 @@ extension StarListViewModel {
         
         return Output(starDataSource: starsRelay.asDriver(onErrorJustReturn: []),
                       date: dateRelay.asDriver(onErrorDriveWith: .empty()),
-                      star: selectedStarRelay.asDriver(onErrorDriveWith: .empty()))
+                      star: selectedStarRelay.asDriver(onErrorDriveWith: .empty()),
+                      restStartComplete: restStartCompleteRelay.asDriver(onErrorDriveWith: .empty()))
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#139 

## 📝 요약(Summary)

휴식 진입 화면에서 타이머가 종료되면 휴식 설정 화면으로 연결되는 기능을 구현했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)
![Simulator Screen Recording - iPhone 16 Pro - 2025-02-11 at 20 51 07](https://github.com/user-attachments/assets/671c6d59-ff09-4b9d-a1fa-b645a24e717a)

## 💬 공유사항 to 리뷰어

- `restStartCompleteRelay`가 방출되면, 시간 설정 모달이 `present` 됨

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
