### PR TITLE
앱 오류에 대한 알럿 기능 구현

### DIFF
--- a/star/star/Resource/en.lproj/Localizable.strings
+++ b/star/star/Resource/en.lproj/Localizable.strings
@@ -61,6 +61,9 @@
 "confirm_create" = "Create STAR";
 "confirm_edit" = "Edit STAR";
 "confirm_set" = "Set Time";
+"warning_title" = "Warning";
+"warning_content" = "There is a bug where the app lock does not unlock even after the star has ended. Please press the refresh button when the star ends.";
+"warning_button" = "OK";  
 
 /// Delay
 "delay" = "Please wait";
@@ -86,7 +89,7 @@
 /// Push Notifications
 "star_will_start" = "%@ starts in 5 min.";
 "star_started" = "%@ has started.";
-"star_completed" = "%@ has ended.";
+"star_completed" = "%@ has ended. Please press the refresh button.”";
 
 /// Shield Configuration
 "shield_restricted_message" = "%@ is restricted.";

--- a/star/star/Resource/ko.lproj/Localizable.strings
+++ b/star/star/Resource/ko.lproj/Localizable.strings
@@ -61,6 +61,9 @@
 "confirm_create" = "생성하기";
 "confirm_edit" = "수정하기";
 "confirm_set" = "설정하기";
+"warning_title" = "경고";
+"warning_content" = "스타가 종료되어도 앱 잠금이 풀리지 않는 버그가 있습니다. 스타가 종료되면 새로고침 버튼을 눌러주세요.";
+"warning_button" = "확인";
 
 /// Delay
 "delay" = "잠시만요";
@@ -86,7 +89,7 @@
 /// Push Notifications
 "star_will_start" = "%@ 스타가 5분 뒤에 시작됩니다.";
 "star_started" = "%@ 스타가 시작되었습니다.";
-"star_completed" = "%@ 스타가 종료되었습니다.";
+"star_completed" = "%@ 스타가 종료되었습니다. 새로고침 버튼을 눌러주세요.";
 
 /// Shield Configuration
 "shield_restricted_message" = "%@은(는)\n사용이 제한되었습니다.";

--- a/star/star/Source/Presentation/StarEdit/StarEditViewController.swift
+++ b/star/star/Source/Presentation/StarEdit/StarEditViewController.swift
@@ -60,6 +60,11 @@ final class StarEditViewController: UIViewController {
         bind()
         setModalAction()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        showWarningAlert()
+    }
 }
 
 // MARK: - Action
@@ -258,6 +263,13 @@ extension StarEditViewController {
     // 모달 종료
     private func closeModal() {
         dismiss(animated: true)
+    }
+
+    // 경고 알럿
+    private func showWarningAlert() {
+        let sheet = UIAlertController(title: "경고", message: "스타가 종료되어도 앱 잠금이 풀리지 않는 버그가 있습니다. 스타가 종료되면 새로고침 버튼을 눌러주세요.", preferredStyle: .alert)
+        sheet.addAction(UIAlertAction(title: "확인" , style: .default))
+        present(sheet, animated: true)
     }
 }
 

--- a/star/star/Source/Presentation/StarEdit/StarEditViewController.swift
+++ b/star/star/Source/Presentation/StarEdit/StarEditViewController.swift
@@ -267,8 +267,8 @@ extension StarEditViewController {
 
     // 경고 알럿
     private func showWarningAlert() {
-        let sheet = UIAlertController(title: "경고", message: "스타가 종료되어도 앱 잠금이 풀리지 않는 버그가 있습니다. 스타가 종료되면 새로고침 버튼을 눌러주세요.", preferredStyle: .alert)
-        sheet.addAction(UIAlertAction(title: "확인" , style: .default))
+        let sheet = UIAlertController(title: "warning_title".localized, message: "warning_content".localized, preferredStyle: .alert)
+        sheet.addAction(UIAlertAction(title: "warning_button".localized , style: .default))
         present(sheet, animated: true)
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#214 

## 📝 요약(Summary)

스타 생성/수정 모달에 진입하면 기능이 제대로 작동하지 않을수도 있다는 알럿을 보여주는 기능을 구현했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-11 at 13 55 56](https://github.com/user-attachments/assets/f30f14b9-0fcc-4fdd-949e-b1fc55dc6065)


## 💬 공유사항 to 리뷰어

- `starEditViewController`의 `viewWillAppear` 메서드가 실행될 때, `showWarningAlert` 메서드가 실행되어 경고 알럿이 나옵니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
