### PR TITLE
Hotfix: 스타 태그가 제대로 적용되지 않는 에러 해결

### DIFF
--- a/star/star.xcodeproj/project.pbxproj
+++ b/star/star.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stargazers.star.ShieldConfiguration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -448,7 +448,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stargazers.star.ShieldConfiguration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -476,7 +476,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stargazers.star.DeviceActivityMonitor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -504,7 +504,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stargazers.star.DeviceActivityMonitor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -538,7 +538,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stargazers.star;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -575,7 +575,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stargazers.star;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/star/star/Source/Presentation/StarList/StarListView/StarListCollectionViewCell.swift
+++ b/star/star/Source/Presentation/StarList/StarListView/StarListCollectionViewCell.swift
@@ -88,7 +88,7 @@ final class StarListCollectionViewCell: UICollectionViewCell {
         tagView.addSubview(tagLabel)
         
         /// 기본값 84, 시스템 언어 ko일때 64 설정
-        let tagViewWidth: CGFloat = Locale.current.languageCode == "ko" ? 60 : 84
+        let tagViewWidth: CGFloat = Locale.current.language.languageCode?.identifier == "ko" ? 60 : 84
         
         tagView.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(16)

--- a/star/star/Source/Presentation/StarList/StarListViewModel/StarListViewModel.swift
+++ b/star/star/Source/Presentation/StarList/StarListViewModel/StarListViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 import UserNotifications
+import UIKit
 
 enum StarModalState {
     
@@ -185,6 +186,14 @@ extension StarListViewModel {
     }
     
     func transform(_ input: Input) -> Output {
+        NotificationCenter.default.rx // foreground 전환 감지
+            .notification(UIApplication.willEnterForegroundNotification)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, _ in
+                owner.fetchData()
+            })
+            .disposed(by: disposeBag)
+        
         refreshRelay
             .withUnretained(self)
             .subscribe(onNext: { owner, _ in


### PR DESCRIPTION
## #️⃣ Issue Number

#232 

## 📝 요약(Summary)

백그라운드에서 일정 시간이 지나면 스타를 `fetch` 하는 메서드가 작동하지 않아, 포그라운드 전환을 감지하는 옵저버를 통해 해결하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)
<img width="408" alt="스크린샷 2025-03-23 21 29 01" src="https://github.com/user-attachments/assets/5f5cf61e-4591-4d3f-8934-a6380ff68a39" />

## 💬 공유사항 to 리뷰어
- 포그라운드 전환이 감지되면 `fetchData`를 실행하여 날짜와 스타를 다시 `fetch` 합니다.


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
