### PR TITLE
TimePicker에 무한 스크롤 효과 적용을 위한 로직 수정

### DIFF
--- a/star/star/Source/Presentation/StarEdit/TimePickerModal/TimePickerModalViewController.swift
+++ b/star/star/Source/Presentation/StarEdit/TimePickerModal/TimePickerModalViewController.swift
@@ -52,12 +52,12 @@ final class TimePickerModalViewController: UIViewController {
         modalView.titleLabel.text = mode.text
         
         // selectRow는 데이터를 로드한 후 실행해야 하므로 DispatchQueue 사용
-        self.modalView.pickerView.selectRow(starTime.hour, // 시간
-                                            inComponent: 0,
-                                            animated: false)
-        self.modalView.pickerView.selectRow(starTime.minute, // 분
-                                            inComponent: 1,
-                                            animated: false)
+        // 중간쯤에 위치
+        let hourMiddle = 24 * 50 + starTime.hour
+        let minuteMiddle = 60 * 50 + starTime.minute
+
+        self.modalView.pickerView.selectRow(hourMiddle, inComponent: 0, animated: false)
+        self.modalView.pickerView.selectRow(minuteMiddle, inComponent: 1, animated: false)
     }
 }
 
@@ -90,8 +90,8 @@ extension TimePickerModalViewController {
     
     private func timeSelect(mode: TimeType) {
         // picker에서 선택한 시간/분
-        let hour = modalView.pickerView.selectedRow(inComponent: 0)
-        let minute = modalView.pickerView.selectedRow(inComponent: 1)
+        let hour = modalView.pickerView.selectedRow(inComponent: 0) % 24
+        let minute = modalView.pickerView.selectedRow(inComponent: 1) % 60
         
         let starTime = StarTime(hour: hour, minute: minute)
         

--- a/star/star/Source/Presentation/StarEdit/TimePickerModal/TimePickerModalViewModel.swift
+++ b/star/star/Source/Presentation/StarEdit/TimePickerModal/TimePickerModalViewModel.swift
@@ -16,8 +16,9 @@ final class TimePickerModalViewModel {
     private let endTimeRelay: PublishRelay<StarTime>
     
     // UIPickerView 데이터
-    let hourData = Observable.just(Array(0...23))  // "0" ~ "23"
-    let minuteData = Observable.just(Array(0...59)) // "0" ~ "59"
+    // 무한 스크롤처럼 보이게
+    let hourData = Observable.just(Array(repeating: Array(0...23), count: 100).flatMap { $0 }) // 2400개
+    let minuteData = Observable.just(Array(repeating: Array(0...59), count: 100).flatMap { $0 }) // 6000개
     
     // 시작시간/종료시간 구분 enum
     let pickerMode: TimeType


### PR DESCRIPTION
## #️⃣ Issue Number

#243 

## 📝 요약(Summary)

시간 선택 피커에서 유저가 무한히 스크롤하는 것처럼 보이도록 하기 위해서 시간/분 데이터를 반복하여 확장하고, 초기 선택 위치를 중간값으로 설정함. 중간 값으로 설정한 이유는 사용자가 아래로 내려 위에 있는 시간을 선택할 수도 있는 선택지가 생겼기 때문에,,,
선택된 값을 계산할 때는 modulo 연산을 통해 실제 시간/분 값을 도출하도록 리팩토링~

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/62fd16b6-01f5-4872-98cc-9f9825096217" width=250 />

## 💬 공유사항 to 리뷰어

UX가 개선되었고, 피커의 상하 경계 없이 자연스럽게 시간을 선택할 수 있게 됐음
구현 방식에 다른 방법이 있었을까? 궁금하긴 합니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
