### PR TITLE
휴식 터치 화면 영역 수정

### DIFF
--- a/star/star/Resource/Localizable.xcstrings
+++ b/star/star/Resource/Localizable.xcstrings
@@ -1027,6 +1027,24 @@
         }
       }
     },
+    "star_list.rest_button" : {
+      "comment" : "스타리스트 화면, 휴식 버튼",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Break"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "쉬는시간"
+          }
+        }
+      }
+    },
     "star_list.status_in_progress" : {
       "comment" : "스타리스트 화면, 진행중 태그",
       "extractionState" : "manual",

--- a/star/star/Resource/Localizable.xcstrings
+++ b/star/star/Resource/Localizable.xcstrings
@@ -805,7 +805,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "전체 >"
           }
         }
@@ -1039,7 +1039,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "쉬는시간"
           }
         }

--- a/star/star/Source/Core/Theme/UIFont.swift
+++ b/star/star/Source/Core/Theme/UIFont.swift
@@ -12,6 +12,7 @@ extension UIFont {
     enum System {
         // size: 12
         static let semibold12 = UIFont.systemFont(ofSize: 12, weight: .semibold)
+        static let medium12 = UIFont.systemFont(ofSize: 12, weight: .medium)
         // size: 14
         static let semibold14 = UIFont.systemFont(ofSize: 14, weight: .semibold)
         // size: 16

--- a/star/star/Source/Presentation/StarList/StarListView/StarListView.swift
+++ b/star/star/Source/Presentation/StarList/StarListView/StarListView.swift
@@ -38,7 +38,19 @@ final class StarListView: UIView, StarrySkyApplicable {
     }
     
     // 휴식 버튼
-    let restButton = UIButton(type: .system)
+    let restButton = UIButton(type: .system).then {
+        var config = UIButton.Configuration.plain()
+        config.baseForegroundColor = .starSecondaryText
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        config.image = UIImage(systemName: "cup.and.saucer.fill")
+        config.imagePadding = 4
+        config.imagePlacement = .top
+        var title = AttributedString.init("Break")
+        title.font = UIFont.System.medium12
+        config.attributedTitle = title
+        $0.configuration = config
+        $0.contentVerticalAlignment = .bottom
+    }
     
     // 시작하기 버튼
     let addStarButton = GradientButton(type: .system).then {
@@ -70,7 +82,6 @@ final class StarListView: UIView, StarrySkyApplicable {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
-        setupRestButton()
     }
     
     required init?(coder: NSCoder) {
@@ -151,21 +162,5 @@ final class StarListView: UIView, StarrySkyApplicable {
         }
         
         addStarButton.applyGradient(colors: [.starButtonPurple, .starButtonNavy], direction: .horizontal)
-    }
-    
-    // 휴식 버튼 설정
-    private func setupRestButton() {
-        var config = UIButton.Configuration.plain()
-        config.baseForegroundColor = .starSecondaryText
-        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-        config.image = UIImage(systemName: "cup.and.saucer.fill")
-        config.imagePadding = 4
-        config.imagePlacement = .top
-        var title = AttributedString.init("REST")
-        title.font = UIFont.System.medium16
-        config.attributedTitle = title
-
-        restButton.configuration = config
-        restButton.contentVerticalAlignment = .bottom
     }
 }

--- a/star/star/Source/Presentation/StarList/StarListView/StarListView.swift
+++ b/star/star/Source/Presentation/StarList/StarListView/StarListView.swift
@@ -37,23 +37,8 @@ final class StarListView: UIView, StarrySkyApplicable {
         $0.font = UIFont.System.semibold16
     }
     
-    // 휴식 뷰
-    private let restView = UIView()
-    
     // 휴식 버튼
-    let restButton = UIButton(type: .system).then {
-        $0.setImage(UIImage(systemName: "cup.and.saucer.fill"), for: .normal)
-        $0.imageView?.contentMode = .scaleAspectFit
-        $0.tintColor = .starSecondaryText
-    }
-    
-    // 휴식 라벨
-    let restButtonLabel = UILabel().then {
-        $0.text = "OFF"
-        $0.font = UIFont.System.medium16
-        $0.textColor = .starSecondaryText
-    }
-    
+    let restButton = UIButton(type: .system)
     
     // 시작하기 버튼
     let addStarButton = GradientButton(type: .system).then {
@@ -85,6 +70,7 @@ final class StarListView: UIView, StarrySkyApplicable {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
+        setupRestButton()
     }
     
     required init?(coder: NSCoder) {
@@ -99,7 +85,7 @@ final class StarListView: UIView, StarrySkyApplicable {
         [
             topView,
             starListCollectionView,
-            restView,
+            restButton,
             noStarLabel,
             toastMessageView,
             addStarButton
@@ -110,13 +96,6 @@ final class StarListView: UIView, StarrySkyApplicable {
             logoTitleLabel,
             todayDateLabel
         ].forEach { topView.addSubview($0) }
-        
-        [
-            restButton,
-            restButtonLabel
-        ].forEach {
-            restView.addSubview($0)
-        }
         
         topView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide.snp.top).inset(16)
@@ -149,20 +128,10 @@ final class StarListView: UIView, StarrySkyApplicable {
             $0.bottom.equalTo(addStarButton.snp.top).offset(-32)
         }
         
-        restView.snp.makeConstraints {
+        restButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(32)
             $0.bottom.equalTo(todayDateLabel.snp.bottom)
             $0.width.height.equalTo(50)
-        }
-        
-        restButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(restButtonLabel.snp.top).offset(-4)
-        }
-        
-        restButtonLabel.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.centerY.equalTo(todayDateLabel.snp.centerY)
         }
         
         addStarButton.snp.makeConstraints {
@@ -182,5 +151,21 @@ final class StarListView: UIView, StarrySkyApplicable {
         }
         
         addStarButton.applyGradient(colors: [.starButtonPurple, .starButtonNavy], direction: .horizontal)
+    }
+    
+    // 휴식 버튼 설정
+    private func setupRestButton() {
+        var config = UIButton.Configuration.plain()
+        config.baseForegroundColor = .starSecondaryText
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        config.image = UIImage(systemName: "cup.and.saucer.fill")
+        config.imagePadding = 4
+        config.imagePlacement = .top
+        var title = AttributedString.init("REST")
+        title.font = UIFont.System.medium16
+        config.attributedTitle = title
+
+        restButton.configuration = config
+        restButton.contentVerticalAlignment = .bottom
     }
 }

--- a/star/star/Source/Presentation/StarList/StarListView/StarListView.swift
+++ b/star/star/Source/Presentation/StarList/StarListView/StarListView.swift
@@ -44,7 +44,7 @@ final class StarListView: UIView, StarrySkyApplicable {
         config.image = UIImage(systemName: "cup.and.saucer.fill")
         config.imagePadding = 4
         config.imagePlacement = .top
-        var title = AttributedString.init("Break")
+        var title = AttributedString.init("star_list.rest_button".localized)
         title.font = UIFont.System.medium12
         config.attributedTitle = title
         $0.configuration = config

--- a/star/star/Source/Presentation/StarList/StarListView/StarListView.swift
+++ b/star/star/Source/Presentation/StarList/StarListView/StarListView.swift
@@ -31,7 +31,6 @@ final class StarListView: UIView, StarrySkyApplicable {
     
     // 오늘 날짜 라벨
     let todayDateLabel = UILabel().then {
-        //        $0.text = "2025년 1월 20일 (월)"
         $0.textColor = .starPrimaryText
         $0.textAlignment = .left
         $0.font = UIFont.System.semibold16

--- a/star/star/Source/Presentation/StarList/StarListViewModel/StarListViewModel.swift
+++ b/star/star/Source/Presentation/StarList/StarListViewModel/StarListViewModel.swift
@@ -142,7 +142,8 @@ final class StarListViewModel {
     
     // 휴식 가능 여부 업데이트
     private func updateRestAvailability() {
-        if starsRelay.value.isEmpty {
+        // 진행중인 스타가 있는지 확인
+        if starsRelay.value.filter({ $0.state().style == .ongoing }).count == 0 {
             unavailabilityRelay.accept(.restUnavailable)
         } else {
             starModalStateRelay.accept(.delay(mode: .rest))


### PR DESCRIPTION
## #️⃣ Issue Number

#264 

## 📝 요약(Summary)

휴식 터치 화면 영역을 수정하고 진행중인 스타가 없을 경우에 대해서도 토스트를 메세지를 지원합니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)
![Simulator Screen Recording - iPhone 16 Pro - 2025-04-11 at 22 18 26](https://github.com/user-attachments/assets/b602481b-0c9b-4990-ae65-1ad770926b63)

## 💬 공유사항 to 리뷰어

- 휴식 버튼 수정
  - '커피 이미지'에서 '커피 이미지 + 라벨'로 터치 가능 영역 확대
  - 기존에는 이미지와 라벨이 각각의 프로퍼티로 존재했으나, 하나의 버튼으로 통합
  - `OFF` 문구가 직관적이지 않아, `REST` 문구로 변경
- 진행중인 스타가 없는데 휴식 버튼을 누르면, 토스트 메세지가 나오게 수정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
